### PR TITLE
Simplified Feed Encodable impl

### DIFF
--- a/status/src/spaceapi.rs
+++ b/status/src/spaceapi.rs
@@ -38,13 +38,12 @@ pub struct Feed {
 // adapted from the generated code
 impl Encodable for Feed {
     fn encode<S: Encoder>(&self, encoder: &mut S) -> Result<(), S::Error> {
-        match *self {
-            Feed { _type: ref p_type, url: ref p_url } =>
-                encoder.emit_struct("Feed", 2usize, |enc| -> _ {
-                    try!(enc.emit_struct_field( "type", 0usize, |enc| p_type.encode(enc)));
-                    return enc.emit_struct_field("url", 1usize, |enc| -> _ { (*p_url).encode(enc) });
-                }),
-        }
+        encoder.emit_struct("Feed", 2usize, |enc| {
+            try!(
+                enc.emit_struct_field("type", 0usize, |enc| self._type.encode(enc))
+            );
+            enc.emit_struct_field("url", 1usize, |enc| self.url.encode(enc))
+        })
     }
 }
 


### PR DESCRIPTION
Some points I noticed:

- The match is not necessary for a single possible type. Simply use the "dot" syntax.
- The return value of a closure can be derived automatically. `|enc| -> _ {` can be simplified to `|enc| {`.
- An explicit return is not necessary, simply leave an expression at the end of the scope.
- I'm not sure why `*p_url` was dereferenced, but `p_type` not. Apparently it's not necessary at all.
- Removed some redundant braces

Before:

```rust
match *self {
    Feed { _type: ref p_type, url: ref p_url } =>
        encoder.emit_struct("Feed", 2usize, |enc| -> _ {
            try!(enc.emit_struct_field( "type", 0usize, |enc| p_type.encode(enc)));
            return enc.emit_struct_field("url", 1usize, |enc| -> _ { (*p_url).encode(enc) });
        }),
}
```

After:

```rust
encoder.emit_struct("Feed", 2usize, |enc| {
    try!(
        enc.emit_struct_field("type", 0usize, |enc| self._type.encode(enc))
    );
    enc.emit_struct_field("url", 1usize, |enc| self.url.encode(enc))
})
```

@rnestler care to review?