### PR TITLE
datastore: Clenup DataStoreError

### DIFF
--- a/spaceapi_server/src/datastore.rs
+++ b/spaceapi_server/src/datastore.rs
@@ -10,20 +10,15 @@ pub trait DataStore : Send {
     fn delete(&self, key: &str) -> Result<(), DataStoreError>;
 }
 
-/// A struct representing a datastore error.
+/// An enum representing a datastore error.
 #[derive(Debug)]
-pub struct DataStoreError {
-    pub repr: ErrorKind,
-}
-
-/// An enum containing all possible error kinds.
-#[derive(Debug)]
-pub enum ErrorKind {
+pub enum DataStoreError {
     RedisError(redis::RedisError),
 }
 
 impl From<redis::RedisError> for DataStoreError {
     fn from(err: redis::RedisError) -> DataStoreError {
-        DataStoreError { repr: ErrorKind::RedisError(err) }
+        DataStoreError::RedisError(err)
     }
 }
+


### PR DESCRIPTION
No need to redirect through a struct. The error type can be an enum.

What I still not like is that while the ``DataStore`` trait enables
out-of-crate implementations, one still has to edit the enum to be able to
return custom errors.

Maybe we should make ``DataStore`` (and all users of it) error type generic.

@dbrgn @schmijos 