### PR TITLE
travis: test with stable and beta, but not nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
+  - stable
   - beta
-  - nightly
 services:
   - redis-server
 env:

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use spaceapi_server::SpaceapiServer;
 use spaceapi_server::datastore::DataStore;
 use spaceapi_server::redis_store::RedisStore;
 
-
+#[cfg_attr(test, allow(dead_code))]
 fn main() {
     let host = Ipv4Addr::new(127, 0, 0, 1);
 


### PR DESCRIPTION
It's probably a good thing if the spaceapi builds with the latest stable
toolchain, not only with beta / nightly.
Also I removed nightly because recently we hit a compiler bug: https://travis-ci.org/coredump-ch/spaceapi/builds/69862138, see https://github.com/rust-lang/rust/pull/26807 which fixed the error.
But maybe that's a good thing, so we uncover bugs in rustc.