### PR TITLE
Server refactoring

### DIFF
--- a/spaceapi/src/lib.rs
+++ b/spaceapi/src/lib.rs
@@ -84,23 +84,27 @@ impl<T> Optional<T> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Location {
     pub address: Optional<String>,
     pub lat: f64,
     pub lon: f64,
 }
 
+#[derive(Debug, Clone)]
 pub struct Spacefed {
     pub spacenet: bool,
     pub spacesaml: bool,
     pub spacephone: bool,
 }
 
+#[derive(Debug, Clone)]
 pub struct Icon {
     pub open: String,
     pub close: String,
 }
 
+#[derive(Debug, Clone)]
 pub struct State {
     pub open: Option<bool>,
     pub lastchange: Optional<u64>,
@@ -109,6 +113,7 @@ pub struct State {
     pub icon: Optional<Icon>,
 }
 
+#[derive(Debug, Clone)]
 pub struct Event {
     pub name: String,
     pub _type: String,
@@ -116,6 +121,7 @@ pub struct Event {
     pub extra: Optional<String>,
 }
 
+#[derive(Debug, Clone)]
 pub struct Contact {
     pub irc: Optional<String>,
     pub twitter: Optional<String>,
@@ -123,11 +129,13 @@ pub struct Contact {
     pub email: Optional<String>,
 }
 
+#[derive(Debug, Clone)]
 pub struct Feed {
     pub _type: Optional<String>,
     pub url: String,
 }
 
+#[derive(Debug, Clone)]
 pub struct Feeds {
     pub blog: Optional<Feed>,
     pub wiki: Optional<Feed>,
@@ -135,11 +143,13 @@ pub struct Feeds {
     pub flickr: Optional<Feed>,
 }
 
+#[derive(Debug, Clone)]
 pub struct Sensors {
     pub people_now_present: Optional<Vec<PeopleNowPresentSensor>>,
     pub temperature: Optional<Vec<TemperatureSensor>>,
 }
 
+#[derive(Debug, Clone)]
 pub struct PeopleNowPresentSensor {
     pub value: u32,
     pub location: Optional<String>,
@@ -148,6 +158,7 @@ pub struct PeopleNowPresentSensor {
     pub description: Optional<String>,
 }
 
+#[derive(Debug, Clone)]
 pub struct TemperatureSensor {
     pub value: f32,
     pub unit: String,
@@ -156,10 +167,12 @@ pub struct TemperatureSensor {
     pub description: Optional<String>,
 }
 
+#[derive(Debug, Clone)]
 pub struct Cache {
     pub schedule: String,
 }
 
+#[derive(Debug, Clone)]
 pub struct RadioShow {
     pub name: String,
     pub url: String,
@@ -169,6 +182,7 @@ pub struct RadioShow {
 }
 
 /// The main Space API status object.
+#[derive(Debug, Clone)]
 pub struct Status {
 
     // Hackerspace properties

--- a/spaceapi_server/src/lib.rs
+++ b/spaceapi_server/src/lib.rs
@@ -14,7 +14,7 @@ use std::net::Ipv4Addr;
 use std::sync::Mutex;
 use std::sync::Arc;
 
-use rustc_serialize::json::ToJson;
+use rustc_serialize::json::{Json, ToJson};
 use iron::{Request, Response, IronResult, Iron, Set};
 use iron::{status, headers, middleware};
 use iron::modifiers::Header;
@@ -23,7 +23,7 @@ pub use datastore::DataStore;
 use spaceapi::Optional::{Value, Absent};
 
 
-fn build_response_json(status: &spaceapi::Status, people_present: Option<u32>, raspi_temperature: Option<f32>) -> String {
+fn build_response_json(status: &spaceapi::Status, people_present: Option<u32>, raspi_temperature: Option<f32>) -> Json {
     let people_present_sensor = match people_present {
         Some(count) => Value(vec![
             spaceapi::PeopleNowPresentSensor {
@@ -42,7 +42,7 @@ fn build_response_json(status: &spaceapi::Status, people_present: Option<u32>, r
             spaceapi::TemperatureSensor {
                 value: degrees,
                 unit: "°C".to_string(),
-                location: "Hackerspace".to_string(),
+                location: "Basement".to_string(),
                 name: Value("Raspberry CPU".to_string()),
                 description: Absent,
             }
@@ -57,8 +57,8 @@ fn build_response_json(status: &spaceapi::Status, people_present: Option<u32>, r
         temperature: temperature_sensor,
     });
 
-    // Serialize to JSON string
-    status_copy.to_json().to_string()
+    // Serialize to JSON
+    status_copy.to_json()
 }
 
 
@@ -119,7 +119,7 @@ impl middleware::Handler for SpaceapiServer {
         };
 
         // Get response body
-        let body = build_response_json(&self.status, people_present, raspi_temperature);
+        let body = build_response_json(&self.status, people_present, raspi_temperature).to_string();
 
         // Create response
         let mut response = Response::with((status::Ok, body));
@@ -136,50 +136,134 @@ impl middleware::Handler for SpaceapiServer {
 
 #[cfg(test)]
 mod test {
-    use super::build_response_json;
+    extern crate spaceapi;
+    extern crate rustc_serialize;
 
-    #[test]
-    /// Verify that the response JSON looks OK.
-    fn verify_response_json() {
+    use super::build_response_json;
+    use spaceapi::Optional;
+    use rustc_serialize::json::Json;
+
+    fn get_test_data() -> Json {
+        // Create minimal status object
+        let ref status = spaceapi::Status::new(
+            "ourspace".to_string(),
+            "https://example.com/logo.png".to_string(),
+            "https://example.com/".to_string(),
+            spaceapi::Location {
+                address: Optional::Value("Street 1, Zürich, Switzerland".to_string()),
+                lat: 47.123,
+                lon: 8.88,
+            },
+            spaceapi::Contact {
+                irc: Optional::Absent,
+                twitter: Optional::Absent,
+                foursquare: Optional::Absent,
+                email: Optional::Value("hi@example.com".to_string()),
+            },
+            vec![
+                "email".to_string(),
+                "twitter".to_string(),
+            ],
+        );
+
+        // Add sensor data, build JSON
         let people_present = Some(23);
         let temperature = Some(42.5);
-        let json = build_response_json(people_present, temperature);
-        assert_eq!(json, "{\
-            \"api\":\"0.13\",\
-            \"cache\":{\"schedule\":\"m.02\"},\
-            \"contact\":{\
-                \"email\":\"danilo@coredump.ch\",\
-                \"foursquare\":\"525c20e5498e875d8231b1e5\",\
-                \"irc\":\"irc://freenode.net/#coredump\",\
-                \"twitter\":\"@coredump_ch\"\
-            },\
-            \"feeds\":{\
-                \"blog\":{\"type\":\"rss\",\"url\":\"https://www.coredump.ch/feed/\"}\
-            },\
-            \"issue_report_channels\":[\"email\",\"twitter\"],\
-            \"location\":{\
-                \"address\":\"Spinnereistrasse 2, 8640 Rapperswil, Switzerland\",\
-                \"lat\":47.22936,\"lon\":8.82949\
-            },\
-            \"logo\":\"https://www.coredump.ch/logo.png\",\
-            \"projects\":[\
-                \"https://www.coredump.ch/projekte/\",\
-                \"https://discourse.coredump.ch/c/projects\",\
-                \"https://github.com/coredump-ch/\"\
-            ],\
-            \"sensors\":{\
-                \"people_now_present\":[{\
-                    \"location\":\"Hackerspace\",\"value\":23\
-                }],\
-                \"temperature\":[{\
-                    \"location\":\"Hackerspace\",\"name\":\"Raspberry CPU\",\
-                    \"unit\":\"°C\",\"value\":42.5\
-                }]\
-            },\
-            \"space\":\"coredump\",\
-            \"spacefed\":{\"spacenet\":false,\"spacephone\":false,\"spacesaml\":false},\
-            \"state\":{\"message\":\"Open every Monday from 20:00\",\"open\":false},\
-            \"url\":\"https://www.coredump.ch/\"\
-        }");
+        build_response_json(status, people_present, temperature)
     }
+
+    #[test]
+    /// Verify that the result is a JSON object.
+    fn verify_json_obj() {
+        let json = get_test_data();
+        assert!(json.is_object());
+    }
+
+    #[test]
+    /// Verify that the result has the correct keys.
+    fn verify_json_keys() {
+        let json = get_test_data();
+        let status = json.as_object().unwrap();  // We get back a BTreeMap<String, Json>
+        let keys: Vec<String> = status.keys().cloned().collect();  // Collect the keys
+        assert_eq!(keys, ["api", "contact", "issue_report_channels", "location",
+                          "logo", "sensors", "space", "state", "url"]);
+    }
+
+    #[test]
+    /// Verify static data
+    fn verify_json_static_data() {
+        let json = get_test_data();
+        let status = json.as_object().unwrap();  // We get back a BTreeMap<String, Json>
+
+        // Strings
+        assert_eq!(status.get("api").unwrap().as_string().unwrap(), "0.13");
+        assert_eq!(status.get("space").unwrap().as_string().unwrap(), "ourspace");
+        assert_eq!(status.get("url").unwrap().as_string().unwrap(), "https://example.com/");
+        assert_eq!(status.get("logo").unwrap().as_string().unwrap(), "https://example.com/logo.png");
+
+        // Channels
+        let channels: &Vec<Json> = status.get("issue_report_channels").unwrap().as_array().unwrap();
+        let channel_values: Vec<String> = channels.iter()
+                                                  .cloned()
+                                                  .map(|c| c.as_string().unwrap().to_string())
+                                                  .collect();
+        assert_eq!(vec!["email", "twitter"], channel_values);
+    }
+
+    #[test]
+    /// Verify location
+    fn verify_json_location() {
+        let json = get_test_data();
+        let status = json.as_object().unwrap();
+        let location = status.get("location").unwrap().as_object().unwrap();
+
+        // Verify data
+        let address = location.get("address").unwrap().as_string().unwrap();
+        assert_eq!("Street 1, Zürich, Switzerland".to_string(), address);
+        assert_eq!(47.123, location.get("lat").unwrap().as_f64().unwrap());
+        assert_eq!(8.88, location.get("lon").unwrap().as_f64().unwrap());
+    }
+
+    #[test]
+    /// Verify contact
+    fn verify_json_contact() {
+        let json = get_test_data();
+        let status = json.as_object().unwrap();
+        let contact = status.get("contact").unwrap().as_object().unwrap();
+
+        // Verify data
+        let email = contact.get("email").unwrap().as_string().unwrap();
+        assert_eq!("hi@example.com".to_string(), email);
+    }
+
+    #[test]
+    /// Verify sensor data
+    fn verify_json_sensors() {
+        let json = get_test_data();
+        let status = json.as_object().unwrap();
+        let sensors = status.get("sensors").unwrap().as_object().unwrap();
+        let temperature_sensor = sensors.get("temperature").unwrap()
+                                        .as_array().unwrap()[0]  // List of sensors
+                                        .as_object().unwrap();  // Sensor object
+        let people_sensor = sensors.get("people_now_present").unwrap()  // List of sensors
+                                        .as_array().unwrap()[0]  // Sensor object
+                                        .as_object().unwrap();
+
+        // Verify temperature sensor
+        let temp_location = temperature_sensor.get("location").unwrap().as_string().unwrap();
+        let temp_name = temperature_sensor.get("name").unwrap().as_string().unwrap();
+        let temp_unit = temperature_sensor.get("unit").unwrap().as_string().unwrap();
+        let temp_value = temperature_sensor.get("value").unwrap().as_f64().unwrap();
+        assert_eq!("Basement".to_string(), temp_location);
+        assert_eq!("Raspberry CPU".to_string(), temp_name);
+        assert_eq!("°C".to_string(), temp_unit);
+        assert_eq!(42.5, temp_value);
+
+        // Verify peoplesensor
+        let people_location = people_sensor.get("location").unwrap().as_string().unwrap();
+        let people_value = people_sensor.get("value").unwrap().as_u64().unwrap();
+        assert_eq!("Hackerspace".to_string(), people_location);
+        assert_eq!(23, people_value);
+    }
+
 }


### PR DESCRIPTION
- We previously didn't use the `Status` instance that was passed into the server. This is now fixed.
- `build_response_json` now returns `Json`, not `String`
- Improved tests

It's another step in the direction of fixing #22.

@rnestler can you review?