### PR TITLE
server: Print full URL on serve()

### DIFF
--- a/spaceapi_server/src/lib.rs
+++ b/spaceapi_server/src/lib.rs
@@ -90,7 +90,7 @@ impl SpaceapiServer {
     pub fn serve(self) {
         let host = self.host;
         let port = self.port;
-        println!("Starting HTTP server on {}:{}...", host, port);
+        println!("Starting HTTP server on http://{}:{}...", host, port);
         Iron::new(self).http((host, port)).unwrap();
     }
 


### PR DESCRIPTION
That way the URL is accessible to open in the browser from my terminal. :smiley: