### PR TITLE
Fixed docker target branch and binary name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,9 @@ RUN apt-get update && \
 WORKDIR /source
 RUN git clone https://github.com/coredump-ch/spaceapi && \
     cd spaceapi && \
-    git checkout docopt && \
     cargo build --release && \
-    cp target/release/coredump-status /usr/local/bin/coredump-status
+    cp target/release/coredump_status /usr/local/bin/coredump_status
 
 # Entry point
 EXPOSE 3000
-CMD ["/usr/local/bin/coredump-status", "-i", "0.0.0.0", "-p", "3000"]
+CMD ["/usr/local/bin/coredump_status", "-i", "0.0.0.0", "-p", "3000"]

--- a/README.rst
+++ b/README.rst
@@ -53,11 +53,11 @@ Docker Image
 To build the docker image (which pulls ``master`` version from Github, not the
 local codebase)::
 
-    $ docker build -t coredump/spaceapi .
+    $ docker build -t coredump/spaceapi:latest .
 
 To run a new container from the image::
 
-    $ PORT=3000
+    $ export PORT=3000
     $ docker run -d -p 127.0.0.1:$PORT:3000 coredump/spaceapi
 
 To stop it again::


### PR DESCRIPTION
Now it simply uses the default branch (in our case `rust`).