### PR TITLE
Implemented to_safe on RedisStore

### DIFF
--- a/spaceapi_server/src/datastore/common.rs
+++ b/spaceapi_server/src/datastore/common.rs
@@ -8,9 +8,15 @@ pub use self::redis::RedisError;
 
 /// A ``DataStore`` needs to implement ``store`` and ``retrieve`` methods.
 pub trait DataStore : Send {
+
+    // Storage related methods
     fn store(&self, key: &str, value: &str) -> Result<(), DataStoreError>;
     fn retrieve(&self, key: &str) -> Result<String, DataStoreError>;
     fn delete(&self, key: &str) -> Result<(), DataStoreError>;
+
+    // Wrap instance into an `Arc(Mutex(Box(...)))` and return it.
+    fn make_safe(self) -> SafeDataStore;
+
 }
 
 /// A datastore wrapped in an Arc, a Mutex and a Box. Safe for use in multithreaded situations.

--- a/spaceapi_server/src/datastore/redis_store.rs
+++ b/spaceapi_server/src/datastore/redis_store.rs
@@ -1,8 +1,10 @@
 extern crate redis;
 
+use std::sync::{Mutex,Arc};
+
 use self::redis::{Client, Commands};
 
-use super::{DataStore, DataStoreError};
+use super::{DataStore, SafeDataStore, DataStoreError};
 
 
 /// A data store for Redis.
@@ -30,6 +32,10 @@ impl DataStore for RedisStore {
         let con = try!(self.client.get_connection());
 
         Ok(try!(con.del(key)))
+    }
+
+    fn make_safe(self) -> SafeDataStore {
+        Arc::new(Mutex::new(Box::new(self)))
     }
 
 }

--- a/spaceapi_server/src/lib.rs
+++ b/spaceapi_server/src/lib.rs
@@ -202,7 +202,7 @@ mod test {
         );
 
         // Create datastore (TODO: Create dummy store for testing?)
-        let datastore = Arc::new(Mutex::new(Box::new(RedisStore::new().unwrap()) as Box<DataStore>));
+        let datastore = RedisStore::new().unwrap().make_safe();
 
         // Initialize server
         let server = SpaceapiServer::new(Ipv4Addr::new(127, 0, 0, 1), 3001, status, datastore);

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ extern crate spaceapi_server;
 
 mod utils;
 
-use std::sync::{Mutex,Arc};
 use docopt::Docopt;
 use spaceapi_server::SpaceapiServer;
 use spaceapi_server::api;
@@ -65,7 +64,7 @@ fn main() {
     );
 
     // Set up datastore
-    let datastore = Arc::new(Mutex::new(Box::new(RedisStore::new().unwrap()) as Box<DataStore>));
+    let datastore = RedisStore::new().unwrap().make_safe();
 
     // Set up server
     let mut server = SpaceapiServer::new(host, port, status, datastore);


### PR DESCRIPTION
This allows us to get rid of this `Arc::new(Mutex::new(Box::new(RedisStore::new().unwrap()) as Box<DataStore>))` stuff :D