### PR TITLE
Alternative datastore

### DIFF
--- a/spaceapi_server/src/datastore/common.rs
+++ b/spaceapi_server/src/datastore/common.rs
@@ -8,9 +8,9 @@ pub use self::redis::RedisError;
 
 /// A ``DataStore`` needs to implement ``store`` and ``retrieve`` methods.
 pub trait DataStore : Send {
-    fn store(&self, key: &str, value: &str) -> Result<(), DataStoreError>;
-    fn retrieve(&self, key: &str) -> Result<String, DataStoreError>;
-    fn delete(&self, key: &str) -> Result<(), DataStoreError>;
+    fn store(&mut self, key: &str, value: &str) -> Result<(), DataStoreError>;
+    fn retrieve(& self, key: &str) -> Result<String, DataStoreError>;
+    fn delete(&mut self, key: &str) -> Result<(), DataStoreError>;
 }
 
 /// A datastore wrapped in an Arc, a Mutex and a Box. Safe for use in multithreaded situations.

--- a/spaceapi_server/src/datastore/common.rs
+++ b/spaceapi_server/src/datastore/common.rs
@@ -20,6 +20,7 @@ pub type SafeDataStore = Arc<Mutex<Box<DataStore>>>;
 #[derive(Debug)]
 pub enum DataStoreError {
     RedisError(redis::RedisError),
+    HashMapError,
 }
 
 impl From<redis::RedisError> for DataStoreError {

--- a/spaceapi_server/src/datastore/hash_map_store.rs
+++ b/spaceapi_server/src/datastore/hash_map_store.rs
@@ -1,0 +1,20 @@
+use super::{DataStore, DataStoreError};
+use std::collections::HashMap;
+
+/// Implement the DataStore methods for HashMap
+impl DataStore for HashMap<String,String> {
+
+    fn store(&self, key: &str, value: &str) -> Result<(), DataStoreError> {
+        Ok(())
+    }
+
+    fn retrieve(&self, key: &str) -> Result<String, DataStoreError> {
+        Err(DataStoreError::HashMapError)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), DataStoreError> {
+        Ok(())
+    }
+
+}
+

--- a/spaceapi_server/src/datastore/hash_map_store.rs
+++ b/spaceapi_server/src/datastore/hash_map_store.rs
@@ -19,6 +19,27 @@ impl DataStore for HashMapStore {
         self.remove(key);
         Ok(())
     }
-
 }
 
+#[cfg(test)]
+mod test {
+    use datastore::DataStore;
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let mut store = HashMapStore::new();
+        store.store("key", "value");
+        let result = store.retrieve("key").unwrap();
+        assert_eq!(result, "value");
+        store.delete("key");
+    }
+
+    #[test]
+    #[should_panic()]
+    fn nonexistant() {
+        let store = HashMapStore::new();
+        store.retrieve("nonexistant").unwrap();
+    }
+
+}

--- a/spaceapi_server/src/datastore/hash_map_store.rs
+++ b/spaceapi_server/src/datastore/hash_map_store.rs
@@ -1,18 +1,22 @@
 use super::{DataStore, DataStoreError};
 use std::collections::HashMap;
 
-/// Implement the DataStore methods for HashMap
-impl DataStore for HashMap<String,String> {
+pub type HashMapStore = HashMap<String,String>;
 
-    fn store(&self, key: &str, value: &str) -> Result<(), DataStoreError> {
+/// Implement the DataStore methods for HashMap
+impl DataStore for HashMapStore {
+
+    fn store(&mut self, key: &str, value: &str) -> Result<(), DataStoreError> {
+        self.insert(key.into(), value.into());
         Ok(())
     }
 
     fn retrieve(&self, key: &str) -> Result<String, DataStoreError> {
-        Err(DataStoreError::HashMapError)
+        self.get(key).map(|v| v.clone()).ok_or(DataStoreError::HashMapError)
     }
 
-    fn delete(&self, key: &str) -> Result<(), DataStoreError> {
+    fn delete(&mut self, key: &str) -> Result<(), DataStoreError> {
+        self.remove(key);
         Ok(())
     }
 

--- a/spaceapi_server/src/datastore/mod.rs
+++ b/spaceapi_server/src/datastore/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod common;  
 mod redis_store;
+mod hash_map_store;
 
 #[doc(inline)]
 pub use self::common::{DataStore, DataStoreError, SafeDataStore};

--- a/spaceapi_server/src/datastore/redis_store.rs
+++ b/spaceapi_server/src/datastore/redis_store.rs
@@ -13,7 +13,7 @@ pub struct RedisStore {
 /// Implement the DataStore methods for Redis
 impl DataStore for RedisStore {
 
-    fn store(&self, key: &str, value: &str) -> Result<(), DataStoreError> {
+    fn store(&mut self, key: &str, value: &str) -> Result<(), DataStoreError> {
         let con = try!(self.client.get_connection());
 
         try!(con.set(key, value));
@@ -26,7 +26,7 @@ impl DataStore for RedisStore {
         Ok(try!(con.get(key)))
     }
 
-    fn delete(&self, key: &str) -> Result<(), DataStoreError> {
+    fn delete(&mut self, key: &str) -> Result<(), DataStoreError> {
         let con = try!(self.client.get_connection());
 
         Ok(try!(con.del(key)))
@@ -48,7 +48,7 @@ mod test {
 
     #[test]
     fn roundtrip() {
-        let rs = RedisStore::new().unwrap();
+        let mut rs = RedisStore::new().unwrap();
         rs.store("key", "value");
         let result = rs.retrieve("key").unwrap();
         assert_eq!(result, "value");


### PR DESCRIPTION
So I implemented an alternative `DataStore` backend using a simple HashMap. This could be useful when writing unit tests since they are independent of any redis server and thus have no side effects.