### PR TITLE
spaceapi: Rename utils module to optional

### DIFF
--- a/spaceapi/src/lib.rs
+++ b/spaceapi/src/lib.rs
@@ -15,7 +15,7 @@
 //!     # extern crate rustc_serialize;
 //!     # extern crate spaceapi;
 //!     # use spaceapi::{Status, Location, Contact};
-//!     # use spaceapi::utils::Optional;
+//!     # use spaceapi::optional::Optional;
 //!     use rustc_serialize::json::ToJson;
 //!
 //!     # fn main() {
@@ -48,7 +48,7 @@
 extern crate log;
 extern crate rustc_serialize;
 
-pub mod utils;
+pub mod optional;
 pub mod sensors;
 mod status;
 pub use status::*;

--- a/spaceapi/src/optional.rs
+++ b/spaceapi/src/optional.rs
@@ -26,15 +26,15 @@ impl<T> Optional<T> {
     /// # Examples
     ///
     /// ```
-    /// # use spaceapi::utils::Optional;
-    /// # use spaceapi::utils::Optional::{Value,Absent};
+    /// # use spaceapi::optional::Optional;
+    /// # use spaceapi::optional::Optional::{Value,Absent};
     /// let x = Value("air");
     /// assert_eq!(x.unwrap(), "air");
     /// ```
     ///
     /// ```{.should_panic}
-    /// # use spaceapi::utils::Optional;
-    /// # use spaceapi::utils::Optional::{Value,Absent};
+    /// # use spaceapi::optional::Optional;
+    /// # use spaceapi::optional::Optional::{Value,Absent};
     /// let x: Optional<&str> = Absent;
     /// assert_eq!(x.unwrap(), "air"); // fails
     /// ```
@@ -50,8 +50,8 @@ impl<T> Optional<T> {
     /// # Examples
     ///
     /// ```
-    /// # use spaceapi::utils::Optional;
-    /// # use spaceapi::utils::Optional::{Value,Absent};
+    /// # use spaceapi::optional::Optional;
+    /// # use spaceapi::optional::Optional::{Value,Absent};
     /// let k = 10;
     /// assert_eq!(Value(4).unwrap_or_else(|| 2 * k), 4);
     /// assert_eq!(Absent.unwrap_or_else(|| 2 * k), 20);
@@ -70,8 +70,8 @@ impl<T> Optional<T> {
     /// Convert an `Optional<String>` into an `Optional<usize>`, consuming the original:
     ///
     /// ```
-    /// # use spaceapi::utils::Optional;
-    /// # use spaceapi::utils::Optional::{Value,Absent};
+    /// # use spaceapi::optional::Optional;
+    /// # use spaceapi::optional::Optional::{Value,Absent};
     /// let num_as_str: Optional<String> = Value("10".to_string());
     /// // `Optional::map` takes self *by value*, consuming `num_as_str`
     /// let num_as_int: Optional<usize> = num_as_str.map(|n| n.len());
@@ -116,8 +116,8 @@ impl<T> Optional<T> {
     /// # Examples
     ///
     /// ```
-    /// # use spaceapi::utils::Optional;
-    /// # use spaceapi::utils::Optional::{Value,Absent};
+    /// # use spaceapi::optional::Optional;
+    /// # use spaceapi::optional::Optional::{Value,Absent};
     /// fn sq(x: u32) -> Optional<u32> { Value(x * x) }
     /// fn nope(_: u32) -> Optional<u32> { Absent }
     ///
@@ -138,8 +138,8 @@ impl<T> Optional<T> {
     /// # Examples
     ///
     /// ```
-    /// # use spaceapi::utils::Optional;
-    /// # use spaceapi::utils::Optional::{Value,Absent};
+    /// # use spaceapi::optional::Optional;
+    /// # use spaceapi::optional::Optional::{Value,Absent};
     /// let x: Optional<u32> = Value(2);
     /// assert_eq!(x.is_absent(), false);
     ///
@@ -160,8 +160,8 @@ impl<T> Into<Option<T>> for Optional<T> {
     /// # Examples
     ///
     /// ```
-    /// # use spaceapi::utils::Optional;
-    /// # use spaceapi::utils::Optional::{Value,Absent};
+    /// # use spaceapi::optional::Optional;
+    /// # use spaceapi::optional::Optional::{Value,Absent};
     /// let x: Optional<u32> = Value(2);
     /// assert_eq!(Some(2), x.into());
     ///

--- a/spaceapi/src/sensors.rs
+++ b/spaceapi/src/sensors.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 use rustc_serialize::json::{Json, ToJson};
-use utils::Optional;
+use optional::Optional;
 
 
 //--- Templates ---//

--- a/spaceapi/src/status.rs
+++ b/spaceapi/src/status.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use rustc_serialize::json::{Json, ToJson};
-pub use utils::Optional;
+pub use optional::Optional;
 pub use sensors::{SensorTemplate, Sensors};
 pub use sensors::{TemperatureSensor, PeopleNowPresentSensor};
 

--- a/spaceapi_server/src/lib.rs
+++ b/spaceapi_server/src/lib.rs
@@ -19,7 +19,7 @@ use iron::modifiers::Header;
 
 pub use spaceapi as api;
 use datastore::SafeDataStore;
-use spaceapi::utils::Optional;
+use spaceapi::optional::Optional;
 use spaceapi::SensorTemplate;
 
 
@@ -134,7 +134,7 @@ mod test {
     use std::net::Ipv4Addr;
     use std::sync::{Mutex,Arc};
     use rustc_serialize::json::Json;
-    use spaceapi::utils::Optional;
+    use spaceapi::optional::Optional;
     use super::SpaceapiServer;
     use super::datastore::{DataStore, RedisStore};
 


### PR DESCRIPTION
The utils module contained only the Optional<T> struct. Also utils is a
very bad name for a module.