### PR TITLE
server: Fix warnings in doc tests

### DIFF
--- a/spaceapi_server/src/datastore/hash_map_store.rs
+++ b/spaceapi_server/src/datastore/hash_map_store.rs
@@ -29,10 +29,10 @@ mod test {
     #[test]
     fn roundtrip() {
         let mut store = HashMapStore::new();
-        store.store("key", "value");
+        store.store("key", "value").unwrap();
         let result = store.retrieve("key").unwrap();
         assert_eq!(result, "value");
-        store.delete("key");
+        store.delete("key").unwrap();
     }
 
     #[test]

--- a/spaceapi_server/src/datastore/redis_store.rs
+++ b/spaceapi_server/src/datastore/redis_store.rs
@@ -49,10 +49,10 @@ mod test {
     #[test]
     fn roundtrip() {
         let mut rs = RedisStore::new().unwrap();
-        rs.store("key", "value");
+        rs.store("key", "value").unwrap();
         let result = rs.retrieve("key").unwrap();
         assert_eq!(result, "value");
-        rs.delete("key");
+        rs.delete("key").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
We had some warnings in the doc tests about unused return values:
```
src/datastore/redis_store.rs:52:9: 52:34 warning: unused result which must be used, #[warn(unused_must_use)] on by default
src/datastore/redis_store.rs:52         rs.store("key", "value");
                                        ^~~~~~~~~~~~~~~~~~~~~~~~~
```
By unwrapping them we fix the warnings and make sure that the unit test will fail.