### PR TITLE
Redis config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && \
     build-essential \
     ca-certificates \
     curl \
-    git \
     libssl-dev && \
   curl -sO https://static.rust-lang.org/dist/rust-$RUST_VERSION-x86_64-unknown-linux-gnu.tar.gz && \
   tar -xzf rust-$RUST_VERSION-x86_64-unknown-linux-gnu.tar.gz && \
@@ -26,11 +25,14 @@ RUN apt-get update && \
 
 # Build spaceapi
 WORKDIR /source
-RUN git clone https://github.com/coredump-ch/spaceapi && \
-    cd spaceapi && \
-    cargo build --release && \
+COPY . /source
+RUN cargo build --release && \
     cp target/release/coredump_status /usr/local/bin/coredump_status && \
     cd / && rm -rf /source
+
+# Set runtime related environment variables
+ENV RUST_LOG=warn,spaceapi=info,spaceapi_server=info \
+    REDIS_HOST=spaceapi-redis
 
 # Entry point
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -81,19 +81,25 @@ We currently store data in the following two redis keys:
 
 ## Docker Image
 
-To build the docker image (which pulls `master` version from Github, not the
-local codebase):
+To build the docker image based on the current codebase:
 
     $ docker build -t coredump/spaceapi:latest .
 
-To run a new container from the image:
+If you want to test this using a redis database, first launch a redis container:
+
+    $ docker run -d --name spaceapi-redis redis:3.0
+
+Then launch a new container from the image:
 
     $ export PORT=3000
-    $ docker run -d --name spaceapi -p 127.0.0.1:$PORT:3000 coredump/spaceapi
+    $ docker run -d --name spaceapi -p 127.0.0.1:$PORT:3000 --link spaceapi-redis coredump/spaceapi
+
+(If you don't need a datastore, you can also leave away the redis container and the `--link` argument.)
 
 To stop it again:
 
-    $ docker stop <container-id>
+    $ docker stop spaceapi
+    $ docker stop spaceapi-redis
 
 
 ## Docs


### PR DESCRIPTION
The Redis datastore should be configurable through env vars. This allows us to link a Docker container against a Redis container.